### PR TITLE
refactor: centralize database config

### DIFF
--- a/config/db_config.py
+++ b/config/db_config.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DB_URI = "mysql+pymysql://root:112224@127.0.0.1:3306/water_report?charset=utf8mb4"
+
+engine = create_engine(DB_URI, echo=False, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)

--- a/src/database/db_oil_schema.py
+++ b/src/database/db_oil_schema.py
@@ -1,13 +1,7 @@
-from sqlalchemy import Column, Integer, String, Date, Text, create_engine, UniqueConstraint
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import Column, Integer, String, Date, Text, UniqueConstraint
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.ext.declarative import declared_attr
-
-# 数据库连接配置
-DB_URI = "mysql+pymysql://root:112224@127.0.0.1:3306/water_report?charset=utf8mb4"
-
-
-engine = create_engine(DB_URI, echo=False, pool_pre_ping=True)
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+from config.db_config import engine, SessionLocal
 
 Base = declarative_base()
 

--- a/src/database/db_schema.py
+++ b/src/database/db_schema.py
@@ -1,18 +1,11 @@
 # db_schema.py
 from sqlalchemy import (
     Column, String, Integer, BigInteger, Date, DECIMAL, ForeignKey,
-    UniqueConstraint, create_engine,Enum, TIMESTAMP, func
+    UniqueConstraint, Enum, TIMESTAMP, func
 )
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy.orm import declarative_base, relationship
+from config.db_config import engine, SessionLocal
 from core.enums import AccountPermissionEnum
-
-# ---------- 数据库 URI ----------
-DB_URI = "mysql+pymysql://root:112224@127.0.0.1:3306/water_report?charset=utf8mb4"
-
-
-# ---------- 引擎 & 会话 ----------
-engine = create_engine(DB_URI, echo=False, pool_pre_ping=True)
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False,expire_on_commit=False)
 Base = declarative_base()
 
 

--- a/src/formula.py
+++ b/src/formula.py
@@ -1,5 +1,6 @@
 import sys
 import pymysql
+from config.db_config import DB_URI
 from PyQt5.QtWidgets import (QTableWidget, QTableWidgetItem, QPushButton, QVBoxLayout, QHBoxLayout,
                              QDialogButtonBox, QDialog, QApplication, QComboBox, QMenu, QLineEdit, QMessageBox)
 from PyQt5.QtCore import Qt
@@ -241,10 +242,8 @@ class FormulaImportDialog(QDialog):
         """将表格内容导出到MySQL数据库，增加重复判断逻辑"""
         try:
             # 从DB_URI解析连接参数
-            db_uri = "mysql+pymysql://root:112224@127.0.0.1:3306/water_report?charset=utf8mb4"
-
             import re
-            match = re.match(r'mysql\+pymysql://(\w+):(\w+)@([\d\.]+):(\d+)/(\w+)\?charset=(\w+)', db_uri)
+            match = re.match(r'mysql\+pymysql://(\w+):(\w+)@([\d\.]+):(\d+)/(\w+)\?charset=(\w+)', DB_URI)
             if not match:
                 raise ValueError("无效的DB_URI格式")
 


### PR DESCRIPTION
## Summary
- centralize database connection settings in `config/db_config.py`
- update database schemas to reuse shared config
- refactor formula import dialog to pull DB URI from config

## Testing
- `python -m py_compile config/db_config.py src/database/db_schema.py src/database/db_oil_schema.py src/formula.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c24d4319c8326ab63014292855d47