### PR TITLE
fix: handle login controller execution path

### DIFF
--- a/src/controller/login_controller.py
+++ b/src/controller/login_controller.py
@@ -1,6 +1,17 @@
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication
 
+import os
+import sys
+
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime fix
+    module_dir = os.path.dirname(os.path.abspath(__file__))
+    src_dir = os.path.dirname(module_dir)
+    project_root = os.path.dirname(src_dir)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    __package__ = "src.controller"
+
 from ..view.login_view import LoginView
 from ..database import user_account_dao as user_dao
 


### PR DESCRIPTION
## Summary
- ensure `login_controller` can resolve package imports when executed directly by adjusting `sys.path`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c2ef58bd083268fd99be0c321c758