### PR TITLE
Fix missing engine import in oil report DAO

### DIFF
--- a/src/database/oil_report_dao.py
+++ b/src/database/oil_report_dao.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
-from database.db_oil_schema import OilWellReports, engine
+from database.db_oil_schema import OilWellReports
+from config.db_config import engine
 from datetime import date, timedelta
 
 


### PR DESCRIPTION
## Summary
- import SQLAlchemy engine from config.db_config instead of db_oil_schema in oil_report_dao

## Testing
- `pytest`
- `PYTHONPATH=src python - <<'PY'
from database.oil_report_dao import MySQLManager
print('import succeeded, engine exists:', hasattr(MySQLManager(), 'engine'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689c3b7592fc83268be241b4ce8ca5ad